### PR TITLE
Updated playbook.yml for FF-MPEG location

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -481,7 +481,7 @@
   hosts: ffmpeg-box 
   tasks:
       - name: Download FFmpeg
-        get_url: url=http://johnvansickle.com/ffmpeg/releases/ffmpeg-2.6.1-64bit-static.tar.xz dest=/root/ffmpeg.tar.xz mode=444
+        get_url: url=http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz dest=/root/ffmpeg.tar.xz mode=444
       - name: Unpack FFmpeg
         unarchive: src=/root/ffmpeg.tar.xz dest=/opt copy=no owner=root group=root creates=/opt/ffmpeg-2.6.1-64bit-static/ffprobe
       - name: Soft-link FFmpeg


### PR DESCRIPTION
Updated the playbook.yml to include the new URL for the FF-MPEG location since it's been updated. The old link no longer works and breaks the vagrant provision.

It appears to be a more generic file name with 'release' instead of a specific release specified, so hopefully this is the last time this is broken.
