### PR TITLE
Updated the output directories for the FF-MPEG

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -483,9 +483,9 @@
       - name: Download FFmpeg
         get_url: url=http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz dest=/root/ffmpeg.tar.xz mode=444
       - name: Unpack FFmpeg
-        unarchive: src=/root/ffmpeg.tar.xz dest=/opt copy=no owner=root group=root creates=/opt/ffmpeg-2.6.1-64bit-static/ffprobe
+        unarchive: src=/root/ffmpeg.tar.xz dest=/opt copy=no owner=root group=root creates=/opt/ffmpeg-2.7.2-64bit-static/ffprobe
       - name: Soft-link FFmpeg
-        file: src=/opt/ffmpeg-2.6.1-64bit-static path=/opt/ffmpeg state=link
+        file: src=/opt/ffmpeg-2.7.2-64bit-static path=/opt/ffmpeg state=link
       - name: Set permissions on the opt directory
         file: path=/opt owner=root group=root recurse=true state=directory
 


### PR DESCRIPTION
Forgot to update the output directories for the new FF-MPEG binaries. It appears that instead now it still uses a version-ed output directory, which still causes this issue.
